### PR TITLE
set to bypass on MPUREG_INT_PIN_CFG for AK8963

### DIFF
--- a/MPU9250.cpp
+++ b/MPU9250.cpp
@@ -83,7 +83,7 @@ bool MPU9250::init(bool calib_gyro, bool calib_acc){
         {BITS_FS_250DPS, MPUREG_GYRO_CONFIG},    // +-250dps
         {BITS_FS_2G, MPUREG_ACCEL_CONFIG},       // +-2G
         {my_low_pass_filter_acc, MPUREG_ACCEL_CONFIG_2}, // Set Acc Data Rates, Enable Acc LPF , Bandwidth 184Hz
-        {0x30, MPUREG_INT_PIN_CFG},      //
+        {0x12, MPUREG_INT_PIN_CFG},      //
         //{0x40, MPUREG_I2C_MST_CTRL},   // I2C Speed 348 kHz
         //{0x20, MPUREG_USER_CTRL},      // Enable AUX
         {0x30, MPUREG_USER_CTRL},        // I2C Master mode and set I2C_IF_DIS to disable slave mode I2C bus


### PR DESCRIPTION
Stock library could not detect my AK8963.  As suggested by https://github.com/kriswiner/MPU-9250/issues/62, I changed to 0x22 and it worked.  Using recommended 0x12 which works as well.